### PR TITLE
[feat]: Dropdown 공통 컴포넌트 구현, [bug]: App.tsx에서 발생한 import 오류 해결

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,5 +1,5 @@
 import { RouterProvider } from "react-router-dom";
-import { RrutripThemeProvider } from "./context/ThemeContext";
+import { RoutripThemeProvider } from "./context/ThemeContext";
 import { router } from "./routes/router";
 import { QueryClientProvider } from "@tanstack/react-query";
 import { queryClient } from "./apis/queryClient";
@@ -8,9 +8,9 @@ import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
 function App() {
   return (
     <QueryClientProvider client={queryClient}>
-      <RrutripThemeProvider>
+      <RoutripThemeProvider>
         <RouterProvider router={router} />
-      </RrutripThemeProvider>
+      </RoutripThemeProvider>
       <ReactQueryDevtools />
     </QueryClientProvider>
   );

--- a/client/src/components/common/Dropdown.tsx
+++ b/client/src/components/common/Dropdown.tsx
@@ -1,0 +1,87 @@
+import useOnClickOutside from "@/hooks/useOnClickOutside";
+import React, { useRef, useState } from "react";
+import styled from "styled-components";
+
+interface Props {
+  children: React.ReactNode;
+  toggleIcon: React.ReactNode;
+}
+
+const Dropdown = ({ children, toggleIcon }: Props) => {
+  const [open, setOpen] = useState(false);
+  const dropdouwnRef = useRef<HTMLDivElement>(null);
+
+  useOnClickOutside(dropdouwnRef, () => {
+    setOpen(false);
+  });
+
+  return (
+    <DropdownStyle ref={dropdouwnRef}>
+      <div>
+        <button className="toggle" onClick={() => setOpen((prev) => !prev)}>
+          {toggleIcon}
+        </button>
+      </div>
+      {open && (
+        <div className="panel">
+          <div className="rhombus"></div>
+          {children}
+        </div>
+      )}
+    </DropdownStyle>
+  );
+};
+
+const DropdownStyle = styled.div`
+  position: relative;
+
+  .toggle {
+    margin-left: 1rem;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: none;
+    padding: 0;
+    border: none;
+    cursor: pointer;
+    outline: none;
+
+    svg,
+    path,
+    circle {
+      width: 2.4rem;
+      height: 2.4rem;
+      fill: ${({ theme }) => theme.color.primary};
+      color: ${({ theme }) => theme.color.primary};
+    }
+  }
+
+  .panel {
+    position: absolute;
+    top: 3rem;
+    background-color: ${({ theme }) => theme.color.white};
+    box-shadow: ${({ theme }) => theme.boxShadow.default};
+    border-radius: ${({ theme }) => theme.borderRadius.default};
+    border: 1px solid ${({ theme }) => theme.color.primary};
+    z-index: 100;
+  }
+
+  .rhombus::before {
+    display: inline-block;
+    position: absolute;
+    content: "";
+
+    width: 1rem;
+    height: 1rem;
+    top: -0.55rem;
+    left: 1.6rem;
+    transform: rotate(45deg);
+    background-color: ${({ theme }) => theme.color.white};
+    border: 1px solid ${({ theme }) => theme.color.primary};
+    border-right: none;
+    border-bottom: none;
+    white-space: nowrap;
+  }
+`;
+
+export default Dropdown;

--- a/client/src/hooks/useOnClickOutside.ts
+++ b/client/src/hooks/useOnClickOutside.ts
@@ -1,0 +1,18 @@
+import React, { useEffect } from "react";
+
+const useOnClickOutside = (ref: React.RefObject<HTMLDivElement>, handler: () => void) => {
+  useEffect(() => {
+    const listener = (event: MouseEvent | TouchEvent) => {
+      if (ref.current !== null && !ref.current.contains(event.target as Node)) {
+        handler();
+      }
+    };
+    document.addEventListener("mousedown", listener as EventListener);
+
+    return () => {
+      document.removeEventListener("mousedown", listener as EventListener);
+    };
+  }, [ref, handler]);
+};
+
+export default useOnClickOutside;


### PR DESCRIPTION
## 🔗 관련 이슈 번호
Close #8 

## ✅ PR 유형
변경 사항을 체크해주세요.
- [x] 새로운 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📝 작업한 내용
### 1) Dropdown  컴포넌트 구현
- Dropdown 컴포넌트 props로 버튼 아이콘을 전달합니다.
- Dropdown 컴포넌트 children에는 드롭다운 리스트에 보여질 리스트 항목을 전달합니다.
- 버튼을 다시 한번 더 클릭하거나 버튼 외부를 클릭 시, 드롭 다운 리스트는 사라집니다.
- **💡 참고 사항**
  - 드롭다운 리스트와의 위치를 일치시키기 위해 버튼에 `margin-left: 1rem;`을 주었으니 디자인할 때 참고 바랍니다.
- 마이페이지 버튼 클릭 시 보여지는 드롭다운 리스트 스크린 샷
  ![마이페이지 드롭다운](https://github.com/7days-routrip/routrip/assets/93701887/85e0a503-bdde-485a-a6ce-31ba16d53ed7)
- 더보기 버튼 클릭 시 보여지는 드롭다운 리스트 스크린 샷 
  ![더보기 드롭다운](https://github.com/7days-routrip/routrip/assets/93701887/9b0b37d4-40fd-4c44-b973-e7797e4809b4)

### 2) App.tsx 파일 수정
- 기존의 작업에서 ThemeContext.tsx파일의 컴포넌트명을 수정한 후 App.tsx에서 import할 때 수정된 컴포넌트명으로 변경해주지 않아서 오류가 발생함
- ThemeContext.tsx파일의 바뀐 컴포넌트명으로 import하여 오류 해결

## ✏️ 필요한 후속 작업
<!-- 후속 작업이 필요하다면 적어주세요. -->

## 🔎 참고 자료
<!-- 참고하면 좋을 자료가 있으면 링크를 추가하거나 내용을 적어주세요. -->
