### PR TITLE
fix: 신규 등록하지 않은 장소인데 이미 등록되어 있다는 confirm창이 뜨는 버그 이슈 해결

### DIFF
--- a/client/src/hooks/useAddNewPlace.ts
+++ b/client/src/hooks/useAddNewPlace.ts
@@ -59,18 +59,18 @@ export const useAddNewPlace = (data: Place) => {
 
       if (isNew) {
         // 3. 백엔드 장소 세부 정보 요청에 대해 404 에러를 받고, 추가 로직을 진행한 경우
-        showConfirm("이미 등록된 장소입니다.\n해당 장소를 추가하시겠어요?", () => {
-          addPlace(addData);
-          setMarkerType("add");
-        });
+        addPlace(addData);
+        setMarkerType("add");
 
         return;
       }
 
       // 4. 백엔드 장소 세부 정보 요청에 대해 200 OK를 받은 경우
       // 사용자의 선택을 확인하고 해당 장소를 프론트 전역 상태에 추가
-      addPlace(addData);
-      setMarkerType("add");
+      showConfirm("이미 등록된 장소입니다.\n해당 장소를 추가하시겠어요?", () => {
+        addPlace(addData);
+        setMarkerType("add");
+      });
     },
 
     onError: async (err: any) => {


### PR DESCRIPTION
## 🔗 관련 이슈 번호
<!-- 관련 이슈 번호를 '#'키워드를 사용하여 연결해주세요. -->
Close #102 
## ✅ PR 유형
변경 사항을 체크해주세요.
- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📝 작업한 내용
<!-- 작업한 내용을 적어주세요. -->
- useAddNewPlace 커스텀 훅의 onSuccess 함수에서 처리하는 로직에서, isNew가 true일때와 false일때의 로직을 바꿔서 작성하는 실수로 인해 버그발생
- isNew가 true일 때와 false일때 처리하는 로직을 서로 바꿔주면서 버그 해결
## ✏️ 필요한 후속 작업
<!-- 후속 작업이 필요하다면 적어주세요. -->

## 🔎 참고 자료
<!-- 참고하면 좋을 자료가 있으면 링크를 추가하거나 내용을 적어주세요. -->
