### PR TITLE
[refactor]: useAddNewPlace 커스텀 훅에 에러 핸들링 추가(신규 장소 등록 커스텀 훅)

### DIFF
--- a/client/src/hooks/useAddNewPlace.ts
+++ b/client/src/hooks/useAddNewPlace.ts
@@ -36,8 +36,8 @@ export const useAddNewPlace = (data: Place) => {
           throw { type: errorType.getPlaceDetailApiError, error: getPlaceDetailApiError };
         }
 
-        // 404 에러인 경우 -> 아직 DB에 저장되지 않은 장소이므로, 추가 요청 로직 수행
-        // a. 구글 api로 장소 상세 정보 요청(장소 이미지 포함)
+        // 404 에러 -> 추가 요청 진행
+        // a. 구글 api로 장소 상세 정보 요청
         const [placeDataFromGoogleError, placeDataFromGoogle] = await to(getPlaceDetail(googleMap, data.id));
 
         if (!placeDataFromGoogle) throw { type: errorType.placeDataFromGoogleError, error: placeDataFromGoogleError };
@@ -65,15 +65,14 @@ export const useAddNewPlace = (data: Place) => {
       };
 
       if (isNew) {
-        // 3. 백엔드 장소 세부 정보 요청에 대해 404 에러를 받고, 추가 로직을 진행한 경우
+        // 3. 신규 장소 등록 요청 성공한 경우
         addPlace(addData);
         setMarkerType("add");
 
         return;
       }
 
-      // 4. 백엔드 장소 세부 정보 요청에 대해 200 OK를 받은 경우
-      // 사용자의 선택을 확인하고 해당 장소를 프론트 전역 상태에 추가
+      // 4. 백엔드 장소 세부 정보 요청 성공한 경우
       showConfirm("이미 등록된 장소입니다.\n해당 장소를 추가하시겠어요?", () => {
         addPlace(addData);
         setMarkerType("add");
@@ -82,13 +81,10 @@ export const useAddNewPlace = (data: Place) => {
 
     onError: async (err: any) => {
       if (err.type === errorType.getPlaceDetailApiError) {
-        // 백엔드 서버로 세부 장소 조회 요청 error (404 제외)
         showAlert("장소 정보를 불어오는데 실패했습니다.\n잠시 후에 다시 시도해주세요.", "error");
       } else if (err.type === errorType.placeDataFromGoogleError) {
-        // 구글 api로 장소 상세 정보를 요청 error
         showAlert("해당 장소에 대한 정보를 불러올 수 없습니다.\n다른 장소를 등록해주세요.", "error");
       } else if (err.type === errorType.addNewPlaceApiError) {
-        // 백엔드 서버로 신규 장소 등록 요청 error
         showAlert("해당 장소를 등록하는데 문제가 발생했습니다.\n잠시 후에 다시 시도해주세요.", "error");
       }
     },


### PR DESCRIPTION
## 🔗 관련 이슈 번호
Close #101 

## ✅ PR 유형
변경 사항을 체크해주세요.
- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [x] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📝 작업한 내용
- `useAddNewPlace` 커스텀 훅에서 에러 핸들링 코드 추가
- `mutationFn`에서 호출한 api에서, 에러가 발생할 경우 발생한 에러의 `type`정보를 함께 `throw` 해준다. 
- `onError`에서는 `err`의 `type`을 확인하고 적절하게 에러를 처리한다.
- 상태코드 `500` 이상의 에러는 `axios` 응답 인터셉터에서 전역으로 처리하도록 해줬음

## ✏️ 필요한 후속 작업
<!-- 후속 작업이 필요하다면 적어주세요. -->

## 🔎 참고 자료
<!-- 참고하면 좋을 자료가 있으면 링크를 추가하거나 내용을 적어주세요. -->
