### PR TITLE
fix: placeImg가 빈 문자열일 경우 오류 수정

### DIFF
--- a/server/src/service/spots.service.ts
+++ b/server/src/service/spots.service.ts
@@ -24,7 +24,8 @@ const register = async (
     throw new Error("이미 등록된 장소가 있습니다.\n해당 장소를 추가하시겠습니까?");
   }
 
-  const placeS3Img = await placeImgUpload(placeImg);
+  let placeS3Img: string = "";
+  if (placeImg.length > 0) placeS3Img = await placeImgUpload(placeImg);
 
   const place: Places = new Places();
   place.id = id;


### PR DESCRIPTION
## 🔗 관련 이슈 번호
<!-- 관련 이슈 번호를 '#'키워드를 사용하여 연결해주세요. -->
#166 신규장소 등록에서 이미지 정보가 비어있을 경우 오류발생
## ✅ PR 유형
변경 사항을 체크해주세요.
- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📝 작업한 내용
<!-- 작업한 내용을 적어주세요. -->
- placeImg가 빈 문자열일 경우 예외처리

## ✏️ 필요한 후속 작업
<!-- 후속 작업이 필요하다면 적어주세요. -->

## 🔎 참고 자료
<!-- 참고하면 좋을 자료가 있으면 링크를 추가하거나 내용을 적어주세요. -->
