### PR TITLE
[fix]: 내가 찜한 장소 api 연동 테스트에서 발생한 버그 해결/[refactor]: 지도 컴포넌트, mapStore 코드 개선

### DIFF
--- a/client/src/components/map/ScheduleGoogleMap.tsx
+++ b/client/src/components/map/ScheduleGoogleMap.tsx
@@ -100,10 +100,16 @@ const ScheduleGoogleMap = () => {
     setClickMarker(place);
 
     if (googleMap) {
-      // googleMap.panTo(place.location); // 1. 마커 위치로 지도 이동
+      const bounds = googleMap.getBounds();
+      if (bounds && !bounds.contains(place.location)) {
+        googleMap.panTo(place.location); // 1. 마커 위치로 지도 이동
+      }
 
       const currentZoom = googleMap.getZoom() || 6;
+
+      // const targetZoom = currentZoom < 6 ? 6 : Math.max(currentZoom, 12);
       const targetZoom = Math.max(currentZoom, 12);
+      console.log(currentZoom, targetZoom);
       googleMap.setZoom(targetZoom); // 2. 줌 비율 조정(확대)
     }
   };
@@ -151,7 +157,7 @@ const ScheduleGoogleMap = () => {
     if (!googleMap) return;
 
     updateMapBounds(googleMap, getPlaceArr());
-  }, [addPlaces, dayPlaces, markerType, dayIndex, googleMap, searchPlaces, nearPlaces]);
+  }, [addPlaces, dayPlaces, markerType, dayIndex, googleMap, searchPlaces, nearPlaces, bookmarkPlaces]);
 
   return isLoaded ? (
     <GoogleMap

--- a/client/src/components/map/ScheduleGoogleMap.tsx
+++ b/client/src/components/map/ScheduleGoogleMap.tsx
@@ -24,8 +24,8 @@ const containerStyle = {
 };
 
 const center = {
-  lat: 20,
-  lng: 90,
+  lat: 38,
+  lng: 128,
 };
 
 const createMarkers = (
@@ -54,7 +54,7 @@ const ScheduleGoogleMap = () => {
     language: "ko",
   });
 
-  const { googleMap, mapCenter, setCenter, setGoogleMap, updateMapBounds } = useMapStore();
+  const { googleMap, setGoogleMap, updateMapBounds } = useMapStore();
   const { addPlaces } = useAddPlaceStore();
   const { markerType, dayIndex, clickMarker, setClickMarker } = useShowMarkerTypeStore();
   const { dayPlaces } = useDayPlaceStore();
@@ -81,7 +81,7 @@ const ScheduleGoogleMap = () => {
 
   const handleChanged = useCallback(() => {
     if (googleMap && googleMap.getCenter()) {
-      setCenter({
+      googleMap.setCenter({
         lat: googleMap.getCenter()?.lat() || center.lat,
         lng: googleMap.getCenter()?.lng() || center.lng,
       });
@@ -100,17 +100,14 @@ const ScheduleGoogleMap = () => {
     setClickMarker(place);
 
     if (googleMap) {
+      const currentZoom = googleMap.getZoom() || 6;
+      const targetZoom = Math.max(currentZoom, 12);
+      googleMap.setZoom(targetZoom); // 1. 줌 비율 조정(확대)
+
       const bounds = googleMap.getBounds();
       if (bounds && !bounds.contains(place.location)) {
-        googleMap.panTo(place.location); // 1. 마커 위치로 지도 이동
+        googleMap.panTo(place.location); // 2. 마커 위치로 지도 이동
       }
-
-      const currentZoom = googleMap.getZoom() || 6;
-
-      // const targetZoom = currentZoom < 6 ? 6 : Math.max(currentZoom, 12);
-      const targetZoom = Math.max(currentZoom, 12);
-      console.log(currentZoom, targetZoom);
-      googleMap.setZoom(targetZoom); // 2. 줌 비율 조정(확대)
     }
   };
 
@@ -150,19 +147,19 @@ const ScheduleGoogleMap = () => {
       default:
         break;
     }
-  }, [addPlaces, dayPlaces, markerType, dayIndex, clickMarker]);
+  }, [addPlaces, dayPlaces, nearPlaces, searchPlaces, bookmarkPlaces, markerType, dayIndex, clickMarker]);
 
   useEffect(() => {
     // 지도에 표시할 마커가 전부 보이도록 지도 경계선을 계산
     if (!googleMap) return;
 
-    updateMapBounds(googleMap, getPlaceArr());
+    updateMapBounds(getPlaceArr());
   }, [addPlaces, dayPlaces, markerType, dayIndex, googleMap, searchPlaces, nearPlaces, bookmarkPlaces]);
 
   return isLoaded ? (
     <GoogleMap
       mapContainerStyle={containerStyle}
-      center={mapCenter}
+      center={center}
       zoom={6}
       onLoad={onLoad}
       onUnmount={onUnmount}

--- a/client/src/components/schedule/AddNewPlace.tsx
+++ b/client/src/components/schedule/AddNewPlace.tsx
@@ -11,18 +11,21 @@ import { useShowMarkerTypeStore } from "@/stores/dayMarkerStore";
 
 const AddNewPlace = () => {
   const { nearPlaces, setNearPlaces } = useNearPlacesStore();
-  const { mapCenter, googleMap } = useMapStore();
+  const { googleMap } = useMapStore();
   const { setMarkerType } = useShowMarkerTypeStore();
   const { searchKeywordToGoogle, setSearchKeywordToGoogle } = useSearchKeywordStore();
 
   const requestHandler = async (keyword: string) => {
+    if (!googleMap) return;
+
     // 구글 api 장소 검색 요청
     const currentZoom = googleMap?.getZoom() || 6;
     const radius = calculateSearchRadius(currentZoom);
-    // console.log(currentZoom, radius, mapCenter);
+
+    const center = googleMap.getCenter();
     const params: SearchNearByPlacesParams = {
       keyword,
-      location: { lat: mapCenter.lat, lng: mapCenter.lng },
+      location: { lat: center?.lat() || 38, lng: center?.lng() || 128 },
       radius,
     };
 

--- a/client/src/components/schedule/BookmarkPlace.tsx
+++ b/client/src/components/schedule/BookmarkPlace.tsx
@@ -1,6 +1,8 @@
 import styled from "styled-components";
 import PlaceList from "./PlaceList";
 import { useBookmarkPlaces } from "@/hooks/useBookmarkPlaces";
+import { useBookmarkPlacesStore } from "@/stores/bookmarkPlacesStore";
+import Loading from "../common/Loading";
 
 interface Props {
   buttonTitle: React.ReactNode;
@@ -8,11 +10,13 @@ interface Props {
 
 const BookmarkPlace = ({ buttonTitle }: Props) => {
   const { bookmarkPlacesData } = useBookmarkPlaces();
+  const { bookmarkPlaces } = useBookmarkPlacesStore();
+  if (!bookmarkPlacesData) return <Loading />;
 
   return (
     <BookmarkPlaceStyle>
-      {bookmarkPlacesData && bookmarkPlacesData.length > 0 ? (
-        <PlaceList place={bookmarkPlacesData} buttonTitle={buttonTitle} type="bookmarkList" />
+      {bookmarkPlacesData && bookmarkPlaces.length > 0 ? (
+        <PlaceList place={bookmarkPlaces} buttonTitle={buttonTitle} type="bookmarkList" />
       ) : (
         <div className="empty-bookmark-list">찜한 장소 목록이 비어있습니다.</div>
       )}

--- a/client/src/components/schedule/BookmarkPlace.tsx
+++ b/client/src/components/schedule/BookmarkPlace.tsx
@@ -11,6 +11,7 @@ interface Props {
 const BookmarkPlace = ({ buttonTitle }: Props) => {
   const { bookmarkPlacesData } = useBookmarkPlaces();
   const { bookmarkPlaces } = useBookmarkPlacesStore();
+
   if (!bookmarkPlacesData) return <Loading />;
 
   return (

--- a/client/src/components/schedule/DaySchedule.tsx
+++ b/client/src/components/schedule/DaySchedule.tsx
@@ -15,12 +15,12 @@ interface Props {
 
 const DaySchedule = ({ dayIdx, schedulePlaces, isDragDrop = false }: Props) => {
   const { setMarkerType } = useShowMarkerTypeStore();
-  const { googleMap, updateMapBounds } = useMapStore();
+  const { updateMapBounds } = useMapStore();
 
   const handleOnClickDay = useCallback(() => {
     setMarkerType("day", dayIdx);
-    updateMapBounds(googleMap, schedulePlaces);
-  }, [dayIdx, schedulePlaces, googleMap]);
+    updateMapBounds(schedulePlaces);
+  }, [dayIdx, schedulePlaces]);
 
   if (isDragDrop) {
     return (

--- a/client/src/components/schedule/PlaceItem.tsx
+++ b/client/src/components/schedule/PlaceItem.tsx
@@ -47,20 +47,20 @@ const PlaceItem = ({ data, buttonTitle, type, typeIdx, isActive = false, disable
   };
 
   return (
-    <div onClick={handleOnClickPlaceItem}>
-      <PlaceItemStyle $url={data.placeImg ? data.placeImg : logoImage} $isActive={isActive}>
-        {buttonTitle !== "등록" && <div className="place-img"></div>}
-        <div className="detail-container" onClick={handleOnClickPlaceItem}>
-          <div className="place-title">{data.placeName}</div>
-          <div className="place-address">{data.address}</div>
-        </div>
-        {!disabled && (
-          <button className="place-list-btn" onClick={handleOnClick}>
-            {buttonTitle}
-          </button>
-        )}
-      </PlaceItemStyle>
-    </div>
+    // <div onClick={handleOnClickPlaceItem}>
+    <PlaceItemStyle $url={data.placeImg ? data.placeImg : logoImage} $isActive={isActive}>
+      {buttonTitle !== "등록" && <div className="place-img" />}
+      <div className="detail-container" onClick={handleOnClickPlaceItem}>
+        <div className="place-title">{data.placeName}</div>
+        <div className="place-address">{data.address}</div>
+      </div>
+      {!disabled && (
+        <button className="place-list-btn" onClick={handleOnClick}>
+          {buttonTitle}
+        </button>
+      )}
+    </PlaceItemStyle>
+    // </div>
   );
 };
 

--- a/client/src/components/schedule/PlaceTabs.tsx
+++ b/client/src/components/schedule/PlaceTabs.tsx
@@ -24,7 +24,7 @@ interface PlaceTabsProps {
 }
 
 const PlaceTabs = ({ children, active = 0 }: PlaceTabsProps) => {
-  const { googleMap, updateMapBounds } = useMapStore();
+  const { updateMapBounds } = useMapStore();
   const { addPlaces } = useAddPlaceStore();
   const { setMarkerType } = useShowMarkerTypeStore();
   const { nearPlaces } = useNearPlacesStore();
@@ -38,16 +38,16 @@ const PlaceTabs = ({ children, active = 0 }: PlaceTabsProps) => {
 
     if (title === "추가한 장소") {
       setMarkerType("add");
-      updateMapBounds(googleMap, addPlaces);
+      updateMapBounds(addPlaces);
     } else if (title === "장소 선택") {
       setMarkerType("searchApi");
-      updateMapBounds(googleMap, searchPlaces);
+      updateMapBounds(searchPlaces);
     } else if (title === "신규 장소 등록") {
       setMarkerType("searchGoogle");
-      updateMapBounds(googleMap, nearPlaces);
+      updateMapBounds(nearPlaces);
     } else if (title === "내가 찜한 장소") {
       setMarkerType("bookmarkList");
-      updateMapBounds(googleMap, bookmarkPlaces);
+      updateMapBounds(bookmarkPlaces);
     }
   };
 

--- a/client/src/components/schedule/SelectPlace.tsx
+++ b/client/src/components/schedule/SelectPlace.tsx
@@ -11,13 +11,13 @@ const SelectPlace = () => {
   const { searchKeywordToServer, setSearchKeywordToServer } = useSearchKeywordStore();
   const { searchPlaces, setSearchPlaces } = useSearchPlacesStore();
   const { setMarkerType } = useShowMarkerTypeStore();
-  const { mapCenter, googleMap } = useMapStore();
+  const { googleMap } = useMapStore();
 
   const requestHandler = async (searchKeyword: string) => {
     // 서버로 검색 요청
     const zoom = googleMap?.getZoom() || 6;
-    const lat = mapCenter.lat;
-    const lng = mapCenter.lng;
+    const lat = googleMap?.getCenter()?.lat() || 38;
+    const lng = googleMap?.getCenter()?.lng() || 128;
     const keyword = searchKeyword.trim();
 
     if (!keyword) return;

--- a/client/src/hooks/useBookmarkPlaces.ts
+++ b/client/src/hooks/useBookmarkPlaces.ts
@@ -1,12 +1,13 @@
-import { mockRealPlaceDetailWithoutUuid } from "./../utils/makeMockSelectedPlaces";
 import { getBookmarkPlaces } from "@/apis/place.api";
 import { queryKey } from "@/constants/queryKey";
 import { useBookmarkPlacesStore } from "@/stores/bookmarkPlacesStore";
+import { convertBookmarkPlaces } from "@/utils/convertDataType";
 import { useQuery } from "@tanstack/react-query";
 import { useEffect } from "react";
 
 export const useBookmarkPlaces = () => {
   const { setBookmarkPlaces } = useBookmarkPlacesStore();
+
   const { data: bookmarkPlacesData, isLoading: isBookmarkLoading } = useQuery({
     queryKey: [queryKey.bookmarkPlaces],
     queryFn: getBookmarkPlaces,
@@ -17,7 +18,7 @@ export const useBookmarkPlaces = () => {
     if (!bookmarkPlacesData || bookmarkPlacesData.length === 0) {
       setBookmarkPlaces([]);
     } else {
-      setBookmarkPlaces(bookmarkPlacesData);
+      setBookmarkPlaces(convertBookmarkPlaces(bookmarkPlacesData));
     }
   }, [bookmarkPlacesData]);
 

--- a/client/src/hooks/useScheduleDetails.ts
+++ b/client/src/hooks/useScheduleDetails.ts
@@ -8,7 +8,7 @@ import { useQuery } from "@tanstack/react-query";
 import { useEffect } from "react";
 
 export const useScheduleDetails = (id: string | undefined) => {
-  const { setCenter } = useMapStore();
+  const { googleMap } = useMapStore();
   const { setDayPlaces } = useDayPlaceStore();
   const { setMarkerType } = useShowMarkerTypeStore();
 
@@ -19,11 +19,13 @@ export const useScheduleDetails = (id: string | undefined) => {
   });
 
   useEffect(() => {
+    if (!googleMap) return;
+
     if (scheduleDetailData) {
       setDayPlaces(convertScheduleDetailsToDayPlaces(scheduleDetailData));
 
       if (scheduleDetailData.days[0].spots.length === 0) {
-        setCenter({ lat: 38, lng: 128 });
+        googleMap.setCenter({ lat: 38, lng: 128 });
         return;
       }
 

--- a/client/src/models/place.model.ts
+++ b/client/src/models/place.model.ts
@@ -9,7 +9,7 @@ export interface Place {
   placeName: string;
   address: string;
   location: Location;
-  placeImg?: string; // 구글 placePhoto api  -> buffer 형태로 전달받음 -> base64 인코딩해서 저장
+  placeImg?: string;
 }
 
 // 장소 찜 컴포넌트에서 사용할 타입
@@ -17,4 +17,5 @@ export interface PlaceDetails extends Place {
   tel: string;
   openingHours: string[];
   siteUrl: string;
+  isPicked: boolean; // 장소 찜 했는지 여부
 }

--- a/client/src/pages/SchedulePage.tsx
+++ b/client/src/pages/SchedulePage.tsx
@@ -95,6 +95,7 @@ const SchedulePage = () => {
 
     return () => {
       window.removeEventListener("beforeunload", handleBeforeUnload);
+      resetStore();
     };
   }, []);
 

--- a/client/src/stores/mapStore.ts
+++ b/client/src/stores/mapStore.ts
@@ -1,41 +1,33 @@
-import { Location, Place } from "@/models/place.model";
+import { Place } from "@/models/place.model";
 import { create } from "zustand";
 import { SelectedPlace } from "./addPlaceStore";
 
 interface MapStore {
-  mapCenter: Location;
   googleMap: google.maps.Map | null;
-  setCenter: (newCenter: Location) => void;
   setGoogleMap: (map: google.maps.Map | null) => void;
-  updateMapBounds: (map: google.maps.Map | null, places: SelectedPlace[] | Place[]) => void;
+  updateMapBounds: (places: SelectedPlace[] | Place[]) => void;
 }
 
 const initialState: MapStore = {
-  mapCenter: { lat: 38, lng: 128 }, // zoom 5
   googleMap: null,
-  setCenter: () => {},
   setGoogleMap: () => {},
   updateMapBounds: () => {},
 };
 
 export const useMapStore = create<MapStore>((set) => ({
-  mapCenter: initialState.mapCenter,
   googleMap: initialState.googleMap,
-  setCenter: (newCenter: Location) => set({ mapCenter: newCenter }),
   setGoogleMap: (map: google.maps.Map | null) => set({ googleMap: map }),
-  updateMapBounds: (map: google.maps.Map | null, places: SelectedPlace[] | Place[]) => {
+  updateMapBounds: (places: SelectedPlace[] | Place[]) => {
     set((state) => {
       const bounds = new google.maps.LatLngBounds();
 
-      if (map && places.length > 0) {
+      if (state.googleMap && places.length > 0) {
         places.forEach((place) => {
           bounds.extend(new google.maps.LatLng(place.location.lat, place.location.lng));
         });
 
-        map.fitBounds(bounds);
-        return { ...state, mapCenter: { lat: bounds.getCenter().lat(), lng: bounds.getCenter().lng() } };
+        state.googleMap.fitBounds(bounds);
       }
-
       return state;
     });
   },

--- a/client/src/utils/convertDataType.ts
+++ b/client/src/utils/convertDataType.ts
@@ -1,4 +1,5 @@
 import { DaysField } from "@/apis/schedule.api";
+import { Place, PlaceDetails } from "@/models/place.model";
 import { DaysWithUuid, ScheduleDetails, ScheduleDetailsWithUuid } from "@/models/schedule.model";
 import { SelectedPlace } from "@/stores/addPlaceStore";
 import { v4 as uuidv4 } from "uuid";
@@ -21,6 +22,14 @@ export const convertScheduleDetails = (data: ScheduleDetails): ScheduleDetailsWi
     ...data,
     days: daysWithUuid,
   };
+};
+
+// PlaceDetails[] -> 각 요소의 location 필드를 number 타입으로
+export const convertBookmarkPlaces = (data: PlaceDetails[]): Place[] => {
+  return data.map((item) => ({
+    ...item,
+    location: { lat: Number(item.location.lat), lng: Number(item.location.lng) },
+  }));
 };
 
 // ScheduleDetails -> SelectedPlace[][]


### PR DESCRIPTION
## 🔗 관련 이슈 번호
<!-- 관련 이슈 번호를 '#'키워드를 사용하여 연결해주세요. -->

## ✅ PR 유형
변경 사항을 체크해주세요.
- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📝 작업한 내용
<!-- 작업한 내용을 적어주세요. -->
### 1) 내가 찜한 장소 조회 요청에 대한 결과 데이터의 `location` 정보를 읽지 못하는 버그 발생
- JSON타입으로 들어오는 정보는 `string` 타입이라서 `location`의 `lat`과 `lng`를 `Number`로 변환하는 작업이 필요함
- 해결 방법: `convertBookmarkPlaces` 유틸함수를 만들어서 응답 데이터 가공 작업을 진행하도록 수정

### 2)  마커 클릭 시, 지도의 움직임 개선
- 기존: 마커 클릭 시, 자연스러운 이동을 위해 `panTo` 메서드를 이용하여 해당 마커 위치로 지도 중심점을 이동시키는 코드를 제거하고 그냥 지도 `zoom` 배율만 조정해주었음
- 기존대로 할 경우, 지도 마커 움직임 버그 발생
  - 문제 발생: '내가 찜한 장소' 탭 영역 클릭하고 지도에 표시된 마커를 클릭하면 해당 마커 위치로 지도가 이동한다. 하지만 다시 '내가 찜한 장소'탭을 클릭하고 동일한 마커를 클릭하면, 이상한 곳(현재 지도의 중심이 확대된 곳)으로 이동하는 문제 발생
  - 해결 방법: 지도 줌 비율을 먼저 조정한 후, 줌 비율이 조정된 지도 기준으로 계산된 바운더리 내에 현재 클릭한 마커의 위치가 포함되어 있지 않을 경우에만 지도 중심점을 클릭한 마커 위치로 이동시키는 로직 추가

### 3) `mapStore` 수정
- `googleMap`객체를 전역 상태로 다루기 때문에 `mapCenter`나 `setCenter `액션함수는 필요 없을 듯 하여 삭제하고, 해당 변수나 함수를 사용한 파일에서는 직접 `googleMap` 객체에서 중심점을 구하도록 수정함

### 4) place.model.ts 수정
- `PlaceDetails` 인터페이스에 내가 찜한 장소인지 판별하는 `isPicked` 프로퍼티 추가

### 5) 그 외 추가 작업
- 장소 아이템의 '추가', '등록', 삭제아이콘 버튼을 클릭할 때는 마커위에 인포창이 뜨지 않도록 클릭 이벤트 핸들러 위치를 변경
- 일정 등록 페이지 나갈 경우, 기존의 전역 스토어 초기화 코드 추가

## ✏️ 필요한 후속 작업
<!-- 후속 작업이 필요하다면 적어주세요. -->
## 🔎 참고 자료
<!-- 참고하면 좋을 자료가 있으면 링크를 추가하거나 내용을 적어주세요. -->
