### PR TITLE
fix: 일정 상세보기와 수정페이지에서 헤더에 있는 '내 여행' 클릭하여 일정 등록페이지에 들어온 경우 발생한 버그 해결

### DIFF
--- a/client/src/pages/SchedulePage.tsx
+++ b/client/src/pages/SchedulePage.tsx
@@ -92,6 +92,7 @@ const SchedulePage = () => {
       e.preventDefault();
     };
     window.addEventListener("beforeunload", handleBeforeUnload);
+    resetStore();
 
     return () => {
       window.removeEventListener("beforeunload", handleBeforeUnload);


### PR DESCRIPTION
## 🔗 관련 이슈 번호
<!-- 관련 이슈 번호를 '#'키워드를 사용하여 연결해주세요. -->

## ✅ PR 유형
변경 사항을 체크해주세요.
- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📝 작업한 내용
<!-- 작업한 내용을 적어주세요. -->
### 1)  일정 상세보기와 수정페이지에서 헤더에 있는 '내 여행' 클릭하여 일정 등록페이지에 들어온 경우, 이전의 day에 저장된 전역 상태가 남아있는 버그 해결
- `SchedulePage`의 `useEffect`에서 `resetStore` 함수를 호출하여 전역 상태 초기화 진행

## ✏️ 필요한 후속 작업
<!-- 후속 작업이 필요하다면 적어주세요. -->

## 🔎 참고 자료
<!-- 참고하면 좋을 자료가 있으면 링크를 추가하거나 내용을 적어주세요. -->
