### PR TITLE
[refactor]: 마이페이지에서 사용되는 장소 찜 모달 컴포넌트에 전달되는 `onClosed` 함수 수정

### DIFF
--- a/client/src/apis/https.ts
+++ b/client/src/apis/https.ts
@@ -55,10 +55,12 @@ const createClient = (config?: AxiosRequestConfig) => {
         showAlert("이 페이지에 대한 접근 권한이 없습니다.", "error", () => (window.location.href = "/"));
         return;
       } else if (err.response.status === 400) {
-        showAlert("잘못된 요청입니다.\n입력한 정보를 확인하고 다시 시도해주세요.", "error");
+        showAlert(err.response.data.message, "error");
+        console.error(err);
         return;
       } else if (err.response.status >= 500) {
         showAlert("서버에 문제가 발생했습니다.\n잠시 후에 다시 시도해주세요.", "error");
+        console.error(err);
         return;
       }
       return Promise.reject(err);

--- a/client/src/apis/schedule.api.ts
+++ b/client/src/apis/schedule.api.ts
@@ -43,7 +43,12 @@ export const getScheduleDetails = async (id: string) => {
     const { data } = await httpClient.get<ScheduleDetails>(`/journeys/${id}`);
     const convertData = convertScheduleDetails(data);
     return convertData;
-  } catch (err) {
+  } catch (err: any) {
+    if (err.response.statuse === 404) {
+      showAlert("존재하지 않는 일정입니다.", "error", () => (window.location.href = "/mypage?tag=schedules"));
+      return;
+    }
+
     console.error("api ", err);
     throw err;
   }

--- a/client/src/components/common/LikePlaceCard.tsx
+++ b/client/src/components/common/LikePlaceCard.tsx
@@ -7,11 +7,17 @@ import { useState } from "react";
 
 interface Props {
   PlaceProps: PlaceDetails;
+  likePlaceRefetch: () => void;
 }
 
-const LikePlaceCard = ({ PlaceProps }: Props) => {
+const LikePlaceCard = ({ PlaceProps, likePlaceRefetch }: Props) => {
   const MarkIcon = icons.BookmarkIcon;
   const [isModalOpen, setIsModalOpen] = useState(false);
+
+  const hondleOnClosed = () => {
+    setIsModalOpen(false);
+    likePlaceRefetch();
+  };
 
   return (
     <>
@@ -29,7 +35,7 @@ const LikePlaceCard = ({ PlaceProps }: Props) => {
           <span>{PlaceProps.tel}</span>
         </div>
       </LikePlaceCardStyle>
-      {isModalOpen && <PlaceModal placeId={PlaceProps.id} onClosed={() => setIsModalOpen(false)} />}
+      {isModalOpen && <PlaceModal placeId={PlaceProps.id} onClosed={hondleOnClosed} />}
     </>
   );
 };

--- a/client/src/pages/MainPage.tsx
+++ b/client/src/pages/MainPage.tsx
@@ -34,17 +34,16 @@ const dummyPost: Post = {
 const MainPage = () => {
   const { bestPosts, homePosts, abroadPosts, isBestPostsLoading, isHomePostsLoading, isAbroadPostsLoading } = useMain();
 
-  // if (!bestPosts || !homePosts || !abroadPosts || isBestPostsLoading || isHomePostsLoading || isAbroadPostsLoading)
-  //   return <Loading />;
+  if (!bestPosts || !homePosts || !abroadPosts || isBestPostsLoading || isHomePostsLoading || isAbroadPostsLoading)
+    return <Loading />;
 
   return (
     <MainPageStyle>
       <Banner />
       <SlideSection title="🔥HOT한 여행지는 여기!">
-        {/* {Array.from({ length: 10 }, (_, i) => (
-          <MainPostCard key={i} PostPops={dummyPost} />
-        ))} */}
-        {bestPosts && bestPosts.map((post) => <MainPostCard key={post.id} PostPops={post} />)}
+        {bestPosts.map((post) => (
+          <MainPostCard key={post.id} PostPops={post} />
+        ))}
       </SlideSection>
 
       <div className="categories-container">
@@ -70,14 +69,15 @@ const MainPage = () => {
       </div>
 
       <SlideSection title="🚗국내 여행지">
-        {homePosts && homePosts.posts.map((post: Post) => <MainPostCard key={post.id} PostPops={post} />)}
+        {homePosts.posts.map((post: Post) => (
+          <MainPostCard key={post.id} PostPops={post} />
+        ))}
       </SlideSection>
 
       <SlideSection title="✈️해외 여행지">
-        {Array.from({ length: 10 }, (_, i) => (
-          <MainPostCard key={i} PostPops={dummyPost} />
+        {abroadPosts.posts.map((post: Post) => (
+          <MainPostCard key={post.id} PostPops={post} />
         ))}
-        {/* {abroadPosts && abroadPosts.posts.map((post: Post) => <MainPostCard key={post.id} PostPops={post} />)} */}
       </SlideSection>
     </MainPageStyle>
   );

--- a/client/src/pages/MainPage.tsx
+++ b/client/src/pages/MainPage.tsx
@@ -1,4 +1,3 @@
-import { BestPosts } from "@/apis/main.api";
 import CategoryCard from "@/components/common/CategoryCard";
 import GuidePostCard from "@/components/common/GuidePostCard";
 import Loading from "@/components/common/Loading";

--- a/client/src/pages/Mypage.tsx
+++ b/client/src/pages/Mypage.tsx
@@ -111,7 +111,9 @@ const Mypage = () => {
             ? likePosts?.map((item, idx) => <PostCard PostProps={item} key={idx} view="grid" />)
             : null}
           {!isEmptyLikePlace && activeTag[4]
-            ? likePlaces?.map((item, idx) => <LikePlaceCard PlaceProps={item} key={idx} />)
+            ? likePlaces?.map((item, idx) => (
+                <LikePlaceCard PlaceProps={item} likePlaceRefetch={likePlaceRefetch} key={idx} />
+              ))
             : null}
         </div>
       </div>


### PR DESCRIPTION
## 🔗 관련 이슈 번호
<!-- 관련 이슈 번호를 '#'키워드를 사용하여 연결해주세요. -->

## ✅ PR 유형
변경 사항을 체크해주세요.
- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📝 작업한 내용
<!-- 작업한 내용을 적어주세요. -->
### 1) 마이페이지에서 사용되는 장소 찜 모달 컴포넌트에 전달되는 `onClosed `함수 수정
- 마이페이지의 내가 찜한 장소 탭에서 클릭되어 보여지는 장소 찜 모달 컴포넌트에서는 찜하기 해제 요청한 후 모달 컴포넌트를 닫을 때 내가 찜한 장소 데이터를 `refetch`하는 로직을 추가

### 2) 에러 처리 코드 추가
- 전역 에러 처리에서 400 에러에 대한 에러 메세지 코드 수정
- 일정 상세조회 요청에서 404에러에 대한 처리 추가
## ✏️ 필요한 후속 작업
<!-- 후속 작업이 필요하다면 적어주세요. -->
- 메인페이지의 루트립의 추천루트 컴포넌트 클릭 시, 이동할 링크 추가

## 🔎 참고 자료
<!-- 참고하면 좋을 자료가 있으면 링크를 추가하거나 내용을 적어주세요. -->


