### PR TITLE
[fix]: 일정 상세보기 페이지에서 일정 삭제 성공 시 마이페이지 일정 모음 페이지로 이동하는 경로 수정

### DIFF
--- a/client/src/hooks/useScheduleDelete.ts
+++ b/client/src/hooks/useScheduleDelete.ts
@@ -8,7 +8,7 @@ export const useScheduleDelete = (id: string | undefined) => {
 
   const { mutate: deleteScheduleMutate } = useMutation({
     mutationFn: () => (id ? deleteSchedule(id) : Promise.resolve(null)),
-    onSuccess: () => navigate("/mypage"),
+    onSuccess: () => navigate("/mypage?tag=schedules"),
     onError: (err: any) => {
       showAlert("알 수 없는 오류가 발생했습니다.\n문제가 지속될 경우 고객센터로 문의해주세요.", "error");
       console.error(err);

--- a/client/src/pages/PostDetailPage.tsx
+++ b/client/src/pages/PostDetailPage.tsx
@@ -465,7 +465,7 @@ const PostDetailPageStyle = styled.div`
     max-height: 400px;
     width: auto;
     display: block;
-    margin-bottom: 20px
+    margin-bottom: 20px;
     object-fit: contain;
     border-radius: 8px;
     box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
@@ -529,7 +529,7 @@ const PostDetailPageStyle = styled.div`
       .day {
         display: flex;
         align-items: center;
-        gap: 4px
+        gap: 4px;
         white-space: nowrap;
       }
       .route {


### PR DESCRIPTION
## 🔗 관련 이슈 번호
<!-- 관련 이슈 번호를 '#'키워드를 사용하여 연결해주세요. -->

## ✅ PR 유형
변경 사항을 체크해주세요.
- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📝 작업한 내용
<!-- 작업한 내용을 적어주세요. -->
- 일정 상세보기에서 일정 삭제 성공 시, 마이페이지의 일정모음 페이지로 이동하는 경로 수정

## ✏️ 필요한 후속 작업
<!-- 후속 작업이 필요하다면 적어주세요. -->

## 🔎 참고 자료
<!-- 참고하면 좋을 자료가 있으면 링크를 추가하거나 내용을 적어주세요. -->
